### PR TITLE
Updating the Redactor Plugins links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Redactor Clips plugin for Craft
 
-Adds Redactor’s “Clips” [plugin](http://imperavi.com/redactor/docs/plugins/) to Rich Text fields in Craft, which lets you insert predefined code snippets.
+Adds Redactor’s “Clips” [plugin](https://imperavi.com/redactor/plugins/) to Rich Text fields in Craft, which lets you insert predefined code snippets.
 
 You can manage your code snippets from Settings → Plugins → Redactor Clips.
 


### PR DESCRIPTION
Looks like imperavi.com changed up some of their site since this readme was written.
