### PR TITLE
Fixing modal js bug

### DIFF
--- a/redactorclips/resources/clips.js
+++ b/redactorclips/resources/clips.js
@@ -41,7 +41,7 @@ RedactorPlugins.clips = function()
 		{
 			this.modal.load('clips', 'Insert Clips', 400);
 
-			this.modal.createCancelButton();
+			this.modal.getCancelButton();
 
 			$('#redactor-modal-list').find('.redactor-clip-link').each($.proxy(this.clips.load, this));
 


### PR DESCRIPTION
Looks like somewhere along the way the Redactor API renamed the `createCancelButton()` method to `getCancelButton()`.

--- 

@takobell I wasn't sure if I should update the version number and the changelog in the readme for this pull request. Let me know if you'd like me to do that.